### PR TITLE
Retry ramcount correction

### DIFF
--- a/pandaserver/taskbuffer/OraDBProxy.py
+++ b/pandaserver/taskbuffer/OraDBProxy.py
@@ -15475,7 +15475,7 @@ class DBProxy:
                 if taskCoreCount in [0, None, 'NULL']:
                     taskCoreCount = 1
 
-                _logger.debug("{0} : RAM limit task={1}{2} cores={3} baseRamCount={4} job={5}{6} jobPSS={6}kB"
+                _logger.debug("{0} : RAM limit task={1}{2} cores={3} baseRamCount={4} job={5}{6} jobPSS={7}kB"
                               .format(methodName, taskRamCount, taskRamUnit, taskCoreCount, taskBaseRamCount,
                                       jobRamCount, job.minRamUnit, job.maxPSS))
                 
@@ -15515,7 +15515,7 @@ class DBProxy:
                     normalizedJobRamCount = 0
 
                 try:
-                    normalizedMaxPSS = (job.maxPSS - taskBaseRamCount) * 1024.0
+                    normalizedMaxPSS = (job.maxPSS - taskBaseRamCount) / 1024.0
                     if taskRamUnit == 'MBPerCore':
                         normalizedMaxPSS  = normalizedMaxPSS / taskCoreCount
                 except TypeError:
@@ -15535,7 +15535,8 @@ class DBProxy:
 
                 #Ops could have increased task RamCount through direct DB access. In this case don't do anything
                 if (taskRamCount > normalizedJobRamCount) and (normalizedMaxPSS not in [None, 0, 'NULL']) and (taskRamCount > normalizedMaxPSS):
-                    _logger.debug("{0} : task ramcount has already been increased and is higher than maxPSS. Skipping")
+                    _logger.debug("{0} : task ramcount has already been increased and is higher than maxPSS. Skipping".
+                                  format(methodName))
                     return True
                 
                 # skip if already at largest limit
@@ -15575,7 +15576,7 @@ class DBProxy:
                         sqlRL += "AND pandaID=:pandaID AND fileID=:fileID AND attemptNr=:attemptNr"
 
                         self.cur.execute(sqlRL+comment,varMap)
-                        _logger.debug("{0} : increased RAM limit to {1} from {2} for PandaID {3} fileID {4}".format(methodName, nextLimit, jobRamCount, job.PandaID, fileId))
+                        _logger.debug("{0} : increased RAM limit to {1} from {2} for PandaID {3} fileID {4}".format(methodName, nextLimit, normalizedJobRamCount, job.PandaID, fileId))
                 # commit
                 if not self._commit():
                     raise RuntimeError, 'Commit error'

--- a/pandaserver/taskbuffer/OraDBProxy.py
+++ b/pandaserver/taskbuffer/OraDBProxy.py
@@ -15468,7 +15468,7 @@ class DBProxy:
                 sqlUE  = "SELECT ramCount, ramUnit, baseRamCount FROM {0}.JEDI_Tasks ".format(panda_config.schemaJEDI)
                 sqlUE += "WHERE jediTaskID=:jediTaskID "
                 self.cur.execute(sqlUE+comment,varMap)
-                taskRamCount, taskRamUnit, taskBaseRamCount, taskCoreCount = self.cur.fetchone()
+                taskRamCount, taskRamUnit, taskBaseRamCount = self.cur.fetchone()
 
                 if taskBaseRamCount in [0, None, 'NULL']:
                     taskBaseRamCount = 0
@@ -15480,8 +15480,8 @@ class DBProxy:
                           SELECT sc.corecount FROM ATLAS_PANDAMETA.Schedconfig sc
                           WHERE siteId=:site
                           """
-                self.cur.execute(sqlUE+comment,varMap)
-                siteCoreCount = self.cur.fetchone()
+                self.cur.execute(sqlSCC+comment,varMap)
+                siteCoreCount, = self.cur.fetchone()
 
                 if siteCoreCount in [0, None, 'NULL']:
                     siteCoreCount = 1

--- a/pandaserver/taskbuffer/retryModule.py
+++ b/pandaserver/taskbuffer/retryModule.py
@@ -256,7 +256,7 @@ def apply_retrial_rules(task_buffer, jobID, error_source, error_code, error_diag
                     try:
                         # for the CPU time rule the active/passive mode will be applied by the DBProxy function
                         # because we want to monitor the new CPU time in passive mode
-                        new_cputime = task_buffer.increaseCpuTimeTask(jobID, job.jediTaskID, job.computingSite, job.Files, active)
+                        new_cputime = task_buffer.increaseCpuTimeTask(jobID, job.jediTaskID, joSiteb.computing, job.Files, active)
                         #Log to pandamon and logfile
                         message = "increaseCpuTime for PandaID: {0}, jediTaskID: {1} to {2} (active: {3}) . (ErrorSource: {4}. ErrorCode: {5}. ErrorDiag: {6}. Error/action active: {7})"\
                             .format(jobID, job.jediTaskID, new_cputime, active, error_source, error_code, error_diag_rule, active)


### PR DESCRIPTION
task/dataset_content tables use ramUnit, whereas jobs tables are already converted to MB. Retry module needs to consider this situation