### PR TITLE
make fatal events recorded

### DIFF
--- a/pandaserver/taskbuffer/ErrorCode.py
+++ b/pandaserver/taskbuffer/ErrorCode.py
@@ -75,6 +75,9 @@ EC_EventServiceNoEsQueues = 125
 # Closed in bad job status
 EC_EventServiceBadStatus = 126
 
+# There are fatal events in the jobset
+EC_EventServiceFatalEvent = 127
+
 # failed to lock semaphore for job cloning
 EC_JobCloningUnlock = 200
 


### PR DESCRIPTION
In current case, when pilot reports a 'fatal' event status. In panda, it's recorded with 'failed':
1) It's not good for debugging. From bigpanda monitor, we are not sure whether there are 'fatal' events or just 'failed' events with too many retries.
2) retryModule doesn't work with notDiscardEvents. If retryModule disable retries on EC_EventServiceMaxAttempt (114), some processable events will be stopped.

Updates:
1) enable jedi_events to record 'fatal' status from pilot.
2) if an event is 'fatal', the attemptNr will be attemptNr-3
3) for the same event, if there are 3 'fatal' records( some events can be 'fatal' at some site and then successfully processed). the job will fail with EC_EventServiceFatalEvent.