### PR TITLE
fix ddm

### DIFF
--- a/pandaserver/dataservice/DDM.py
+++ b/pandaserver/dataservice/DDM.py
@@ -592,7 +592,7 @@ class RucioAPI:
         client = RucioClient()
         nFiles = 0
         try:
-            for x in client.list_files(scope, dsn):
+            for x in client.list_files(scope, dsn, long=True):
                 nFiles += 1
             return True,nFiles
         except DataIdentifierNotFound:
@@ -613,7 +613,7 @@ class RucioAPI:
         client = RucioClient()
         tSize = 0
         try:
-            for x in client.list_files(scope, dsn):
+            for x in client.list_files(scope, dsn, long=True):
                 tSize += x['bytes']
             return True,tSize
         except DataIdentifierNotFound:


### PR DESCRIPTION
I think the correct fix should be this after I saw this error:

```
2020-02-04 15:41:52,646 panda.log.Adder: DEBUG    4635472953 registerFilesInDatasets {'INFN-NAPOLI-ATLAS_DATADISK': {'hc_test.gangarbt.hc20159095.tid957
.INFN-NAPOLI-RECAS_UCORE.55': [{'guid': '2D4CA79A-149C-7240-A5CD-726A6AAA6C7D', 'lfn': 'output.1.7a9bc660-be9f-48a5-9c9f-ed1607829c57_37907.pool.root', 
'size': 1410888, 'checksum': 'ad:9e1c975a', 'ds': 'hc_test.gangarbt.hc20159095.tid957.INFN-NAPOLI-RECAS_UCORE.55_sub8399635', 'surl': 'root://t2-dpm-01.
na.infn.it:1094//dpm/na.infn.it/home/atlas/atlasdatadisk/rucio/hc_test/67/22/output.1.7a9bc660-be9f-48a5-9c9f-ed1607829c57_37907.pool.root', 'events': 2
, 'panda_id': 4635472953}, {'guid': 'NULL', 'lfn': '7a9bc660-be9f-48a5-9c9f-ed1607829c57_37907.1.job.log.tgz', 'size': 184044, 'checksum': 'ad:46d9d306'
, 'ds': 'hc_test.gangarbt.hc20159095.tid957.INFN-NAPOLI-RECAS_UCORE.55_sub8399635', 'surl': 'root://t2-dpm-01.na.infn.it:1094//dpm/na.infn.it/home/atlas
/atlasdatadisk/rucio/hc_test/2b/54/7a9bc660-be9f-48a5-9c9f-ed1607829c57_37907.1.job.log.tgz', 'events': None, 'panda_id': 4635472953}]}} zip={}
2020-02-04 15:41:52,661 panda.log.Adder: DEBUG    4634820536 end Closer
2020-02-04 15:41:52,661 panda.log.Adder: DEBUG    4634820536 end
2020-02-04 15:41:52,662 panda.log.Adder: DEBUG    4635268013 new start: finished attemptNr=1
2020-02-04 15:41:52,677 panda.log.Adder: DEBUG    4635472953 LFC+DQ2 registration with backend=rucio for 2 files took 0.030 sec
2020-02-04 15:41:52,677 panda.log.Adder: ERROR    4635472953 <class 'rucio.common.exception.InvalidObject'> : Provided object does not match schema.
Details: Problem validating attachments : u'NULL' does not match '^(\\{){0,1}[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]
{12}(\\}){0,1}$'

Failed validating 'pattern' in schema['items']['properties']['dids']['items']['properties']['meta']['properties']['guid']:
    {'description': 'Universally Unique Identifier (UUID)',
     'pattern': '^(\\{){0,1}[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}(\\}){0,1}$',
     'type': 'string'}

On instance[0]['dids'][1]['meta']['guid']:
    u'NULL'Traceback (most recent call last):
  File "/opt/panda/lib64/python3.6/site-packages/pandaserver/dataservice/AdderAtlasPlugin.py", line 586, in _updateOutputs
    out = rucioAPI.registerFilesInDataset(destIdMap, contZipMap)
  File "/opt/panda/lib64/python3.6/site-packages/pandaserver/dataservice/DDM.py", line 266, in registerFilesInDataset
    client.add_files_to_datasets(attachmentList, ignore_duplicate=True)
  File "/opt/panda/lib64/python3.6/site-packages/rucio/client/didclient.py", line 257, in add_files_to_datasets
    ignore_duplicate=ignore_duplicate)
  File "/opt/panda/lib64/python3.6/site-packages/rucio/client/didclient.py", line 244, in attach_dids_to_dids
    raise exc_cls(exc_msg)
rucio.common.exception.InvalidObject: Provided object does not match schema.
Details: Problem validating attachments : u'NULL' does not match '^(\\{){0,1}[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}(\\}){0,1}$'
```

I think the original code (long=long) worked in python2 by coincidence since python2 has the type long.