### PR TITLE
panda daemon: fix hanging taskBufferInterface

### DIFF
--- a/pandaserver/configurator/db_interface.py
+++ b/pandaserver/configurator/db_interface.py
@@ -37,6 +37,10 @@ except exc.SQLAlchemyError:
 def get_session():
     return sessionmaker(bind=__engine)()
 
+
+def engine_dispose():
+    __engine.dispose()
+
 # TODO: The performance of all write methods could significantly be improved by writing in bulks.
 # The current implementation was the fastest way to get it done with the merge method and avoiding
 # issues with duplicate keys

--- a/pandaserver/daemons/scripts/configurator.py
+++ b/pandaserver/daemons/scripts/configurator.py
@@ -58,6 +58,7 @@ def main(argv=tuple(), tbuf=None, **kwargs):
 
     # dbif session close
     session.close()
+    dbif.engine_dispose()
 
 
 # run

--- a/pandaserver/daemons/scripts/copyArchive.py
+++ b/pandaserver/daemons/scripts/copyArchive.py
@@ -128,11 +128,11 @@ def main(argv=tuple(), tbuf=None, **kwargs):
 
 
     # instantiate TB
-    if tbuf is None:
-        from pandaserver.taskbuffer.TaskBuffer import taskBuffer
-        taskBuffer.init(panda_config.dbhost,panda_config.dbpasswd,nDBConnection=1)
-    else:
-        taskBuffer = tbuf
+    # if tbuf is None:
+    from pandaserver.taskbuffer.TaskBuffer import taskBuffer
+    taskBuffer.init(panda_config.dbhost,panda_config.dbpasswd,nDBConnection=1)
+    # else:
+    #     taskBuffer = tbuf
 
 
     # instantiate sitemapper

--- a/pandaserver/daemons/scripts/datasetManager.py
+++ b/pandaserver/daemons/scripts/datasetManager.py
@@ -126,11 +126,11 @@ def main(tbuf=None, **kwargs):
 
 
     # instantiate TB
-    if tbuf is None:
-        from pandaserver.taskbuffer.TaskBuffer import taskBuffer
-        taskBuffer.init(panda_config.dbhost,panda_config.dbpasswd,nDBConnection=1)
-    else:
-        taskBuffer = tbuf
+    # if tbuf is None:
+    from pandaserver.taskbuffer.TaskBuffer import taskBuffer
+    taskBuffer.init(panda_config.dbhost,panda_config.dbpasswd,nDBConnection=1)
+    # else:
+    #     taskBuffer = tbuf
 
     # instantiate sitemapper
     siteMapper = SiteMapper(taskBuffer)

--- a/pandaserver/daemons/scripts/evpPD2P.py
+++ b/pandaserver/daemons/scripts/evpPD2P.py
@@ -59,11 +59,11 @@ def main(tbuf=None, **kwargs):
     #     _logger.error("kill process : %s %s" % (type,value))
 
     # instantiate PD2P
-    if tbuf is None:
-        from pandaserver.taskbuffer.TaskBuffer import taskBuffer
-        taskBuffer.init(panda_config.dbhost,panda_config.dbpasswd,nDBConnection=1)
-    else:
-        taskBuffer = tbuf
+    # if tbuf is None:
+    from pandaserver.taskbuffer.TaskBuffer import taskBuffer
+    taskBuffer.init(panda_config.dbhost,panda_config.dbpasswd,nDBConnection=1)
+    # else:
+    #     taskBuffer = tbuf
     siteMapper = SiteMapper.SiteMapper(taskBuffer)
 
 

--- a/pandaserver/taskbuffer/OraDBProxy.py
+++ b/pandaserver/taskbuffer/OraDBProxy.py
@@ -256,6 +256,8 @@ class DBProxy:
             self.conn.begin()
             self.cur.arraysize = arraySize
             ret = self.cur.execute(sql+comment,varMap)
+            if ret:
+                ret = True
             res = []
             for items in self.cur:
                 resItem = []


### PR DESCRIPTION
Found that TaskBufferInterface sometimes gets blocking when writing the manager dict at [here](https://github.com/PanDAWMS/panda-server/blob/master/pandaserver/taskbuffer/TaskBufferInterface.py#L100) , when DBProxy method is called by threads inside daemon scripts (e.g. copyArchive spawns [Watchers](https://github.com/PanDAWMS/panda-server/blob/master/pandaserver/daemons/scripts/copyArchive.py#L432) , datasetManager spawns CloserThr, Freezer, ...)

When this issue happens, all the daemon processes are blocked (at some DBProxy method throught TaskBufferInterface).
This issue always happens at some moment during copyArchive and datasetManager are running, while I have not seen it happen when those two scripts are not running.

I have not figure out the detail of the reason for this blocking. Maybe some deadlock in manager object vs some threads in other processes.

The solution in my PR is not to use TaskBufferInterface at all in those daemon scripts which launch threads. Instead, they create their own TaskBuffer every cycle they run.
