### PR TITLE
update default timeout

### DIFF
--- a/templates/panda_server-httpd-FastCGI.conf.rpmnew.template
+++ b/templates/panda_server-httpd-FastCGI.conf.rpmnew.template
@@ -1,5 +1,9 @@
 Include conf.modules.d/0*.conf
 
+TimeOut 600
+KeepAliveTimeout 600
+SSLSessionCacheTimeout 600
+
 LoadModule gridsite_module modules/mod_gridsite.so
 LoadModule wsgi_module modules/mod_wsgi.so
 


### PR DESCRIPTION
The default TimeOut is 60 seconds. I saw many timeout errors when testing big tasks from idds side. After manually adding these lines to panda http server. The timeout problem was solved.