### PR TITLE
task eval: keep express analysis tasks in S class

### DIFF
--- a/pandaserver/configurator/Configurator.py
+++ b/pandaserver/configurator/Configurator.py
@@ -383,7 +383,7 @@ class Configurator(threading.Thread):
         schedconfig_sites = self.taskBuffer.configurator_read_cric_sites()
         _logger.debug("Sites in Schedconfig {0}".format(schedconfig_sites))
 
-        all_sites = list(CRIC_sites | configurator_sites | schedconfig_sites)
+        all_sites = list(filter(None, CRIC_sites | configurator_sites | schedconfig_sites))
         all_sites.sort()
 
         for site in all_sites:

--- a/pandaserver/configurator/Configurator.py
+++ b/pandaserver/configurator/Configurator.py
@@ -383,7 +383,7 @@ class Configurator(threading.Thread):
         schedconfig_sites = self.taskBuffer.configurator_read_cric_sites()
         _logger.debug("Sites in Schedconfig {0}".format(schedconfig_sites))
 
-        all_sites = list(filter(None, CRIC_sites | configurator_sites | schedconfig_sites))
+        all_sites = list(CRIC_sites | configurator_sites | schedconfig_sites)
         all_sites.sort()
 
         for site in all_sites:

--- a/pandaserver/daemons/scripts/task_evaluator.py
+++ b/pandaserver/daemons/scripts/task_evaluator.py
@@ -236,6 +236,12 @@ class FetchData(object):
             tmp_log.debug('got total {0} tasks'.format(n_tot_tasks))
             # counter
             cc = 0
+            n_tasks_dict = {
+                    2: 0,
+                    1: 0,
+                    0: 0,
+                    -1: 0,
+                }
             # loop over tasks
             for taskID, user, gshare in active_tasks_list:
                 # initialize
@@ -260,29 +266,33 @@ class FetchData(object):
                         pct_finished = n_files_finished*100/n_files_total
                         pct_failed = n_files_failed*100/n_files_total
                 # classify
-                # parameters
-                progress_to_boost_A = self.tbuf.getConfigValue('analy_eval', 'PROGRESS_TO_BOOST_A')
-                if progress_to_boost_A is None:
-                    progress_to_boost_A = 90
-                progress_to_boost_B = self.tbuf.getConfigValue('analy_eval', 'PROGRESS_TO_BOOST_B')
-                if progress_to_boost_B is None:
-                    progress_to_boost_B = 95
-                # check usage of the user
-                usage_dict = ue_dict.get(user)
-                if usage_dict is None:
-                    continue
-                if usage_dict['rem_slots_A'] <= 0:
-                    if usage_dict['rem_slots_B'] <= 0:
-                        task_class = -1
-                    else:
-                        task_class = 0
-                # boost for nearly done tasks
-                if task_class == 1 and pct_finished >= progress_to_boost_A:
-                    # almost done A-tasks, to boost
+                if gshare == 'Express Analysis':
+                    # Express Analysis tasks always in class S
                     task_class = 2
-                elif task_class == 0 and pct_finished >= progress_to_boost_B:
-                    # almost done B-tasks, to boost
-                    task_class = 2
+                else:
+                    # parameters
+                    progress_to_boost_A = self.tbuf.getConfigValue('analy_eval', 'PROGRESS_TO_BOOST_A')
+                    if progress_to_boost_A is None:
+                        progress_to_boost_A = 90
+                    progress_to_boost_B = self.tbuf.getConfigValue('analy_eval', 'PROGRESS_TO_BOOST_B')
+                    if progress_to_boost_B is None:
+                        progress_to_boost_B = 95
+                    # check usage of the user
+                    usage_dict = ue_dict.get(user)
+                    if usage_dict is None:
+                        continue
+                    if usage_dict['rem_slots_A'] <= 0:
+                        if usage_dict['rem_slots_B'] <= 0:
+                            task_class = -1
+                        else:
+                            task_class = 0
+                    # boost for nearly done tasks
+                    if task_class == 1 and pct_finished >= progress_to_boost_A:
+                        # almost done A-tasks, to boost
+                        task_class = 2
+                    elif task_class == 0 and pct_finished >= progress_to_boost_B:
+                        # almost done B-tasks, to boost
+                        task_class = 2
                 # fill in task class
                 task_dict[taskID] = {
                         'task_id': taskID,
@@ -298,8 +308,10 @@ class FetchData(object):
                 # counter
                 cc += 1
                 if cc % 5000 == 0:
-                    tmp_log.debug('evaluated {0:9d} tasks'.format(cc))
-            tmp_log.debug('evaluated {0:9d} tasks in total'.format(cc))
+                    tmp_log.debug('evaluated {0:6d} tasks'.format(cc))
+                n_tasks_dict[task_class] += 1
+            tmp_log.debug('evaluated {tot:6d} tasks in total (S:{nS}, A:{nA}, B:{nB}, C:{nC})'.format(
+                            tot=cc, nS=n_tasks_dict[2], nA=n_tasks_dict[1], nB=n_tasks_dict[0], nC=n_tasks_dict[-1]))
             # return
             # tmp_log.debug('{}'.format(str([ v for v in task_dict.values() if v['class'] != 1 ])[:3000]))
             tmp_log.debug('done')


### PR DESCRIPTION
The fix in Configurator.py is meant to solve this frequent error in panda daemon:

```
2023-05-14 01:16:12,073 panda.log.daemons: ERROR    daemon_loop <worker_pid=11683> failed to run daemon configurator with TypeError: '<' not supported between instances of 'NoneType' and 'str'
Traceback (most recent call last):
  File "/opt/panda/lib64/python3.6/site-packages/pandaserver/daemons/utils.py", line 218, in daemon_loop
    the_module.main(argv=mod_argv, tbuf=tbuf, lock_pool=lock_pool)
  File "/opt/panda/lib64/python3.6/site-packages/pandaserver/daemons/scripts/configurator.py", line 27, in main
    if not configurator.run():
  File "/opt/panda/lib64/python3.6/site-packages/pandaserver/configurator/Configurator.py", line 490, in run
    self.consistency_check()
  File "/opt/panda/lib64/python3.6/site-packages/pandaserver/configurator/Configurator.py", line 387, in consistency_check
    all_sites.sort()
TypeError: '<' not supported between instances of 'NoneType' and 'str'

 ; stop this worker
```

