### PR TITLE
reduce length in component in process lock table

### DIFF
--- a/pandaserver/daemons/scripts/metric_collector.py
+++ b/pandaserver/daemons/scripts/metric_collector.py
@@ -917,7 +917,7 @@ def main(tbuf=None, **kwargs):
         # loop over all fetch data methods to run and update to DB
         for metric_name, key_type, period in metric_list:
             # metric lock
-            lock_component_name = "pandaMetr.{0:.30}.{1:0x}".format(metric_name, adler32(metric_name.encode("utf-8")))
+            lock_component_name = "pandaMetr.{0:.16}.{1:0x}".format(metric_name, adler32(metric_name.encode("utf-8")))
             # try to get lock
             got_lock = taskBuffer.lockProcess_PANDA(component=lock_component_name, pid=my_full_pid, time_limit=period)
             if got_lock:


### PR DESCRIPTION
To fix the following error:
```
2023-09-29 16:32:11,046 panda.log.DBProxy: ERROR    lockProcess_PANDA <component=pandaMetr.analy_pmerge_jobs_wait_time.9bb40b24 pid=aipanda052-8775-8802>
 lockProcess_PANDA <component=pandaMetr.analy_pmerge_jobs_wait_time.9bb40b24 pid=aipanda052-8775-8802>: DatabaseError ORA-24371: data would not fit in current prefetch buffer Traceback (most recent call last):
  File "/opt/panda/lib/python3.10/site-packages/pandaserver/taskbuffer/OraDBProxy.py", line 24968, in lockProcess_PANDA
    self.cur.execute(sqlCT + comment, varMap)
  File "/opt/panda/lib/python3.10/site-packages/pandaserver/taskbuffer/WrappedCursor.py", line 226, in execute
    ret = cur.execute(sql, varDict)
cx_Oracle.DatabaseError: ORA-24371: data would not fit in current prefetch buffer

```

Strangely, the type of component column is VARCHAR2(56) in JEDI_Process_Lock, but the error pops up when the component string length > about 40. Also, there are very little information on the Internet about ORA-24371 error.