### PR TITLE
Fix typo

### DIFF
--- a/pandaserver/taskbuffer/OraDBProxy.py
+++ b/pandaserver/taskbuffer/OraDBProxy.py
@@ -2673,10 +2673,10 @@ class DBProxy:
                         tmp_log.debug("skip to change from merging")
                     elif oldJobStatus in ["holding", "transferring"] and jobStatus == "starting":
                         # don't update holding
-                        tmp_log.debug("skip to change {1} to {2} to avoid inconsistency".format(oldJobStatus, jobStatus))
+                        tmp_log.debug("skip to change {} to {} to avoid inconsistency".format(oldJobStatus, jobStatus))
                     elif oldJobStatus == "holding" and jobStatus == "running":
                         # don't update holding
-                        tmp_log.debug("skip to change {1} to {2} not to return to active".format(oldJobStatus, jobStatus))
+                        tmp_log.debug("skip to change {} to {} not to return to active".format(oldJobStatus, jobStatus))
                     elif (
                         batchID not in ["", None]
                         and "batchID" in param

--- a/pandaserver/taskbuffer/OraDBProxy.py
+++ b/pandaserver/taskbuffer/OraDBProxy.py
@@ -2673,10 +2673,10 @@ class DBProxy:
                         tmp_log.debug("skip to change from merging")
                     elif oldJobStatus in ["holding", "transferring"] and jobStatus == "starting":
                         # don't update holding
-                        tmp_log.debug("skip to change {} to {} to avoid inconsistency".format(oldJobStatus, jobStatus))
+                        tmp_log.debug(f"skip to change {oldJobStatus} to {jobStatus} to avoid inconsistency")
                     elif oldJobStatus == "holding" and jobStatus == "running":
                         # don't update holding
-                        tmp_log.debug("skip to change {} to {} not to return to active".format(oldJobStatus, jobStatus))
+                        tmp_log.debug(f"skip to change {oldJobStatus} to {jobStatus} not to return to active")
                     elif (
                         batchID not in ["", None]
                         and "batchID" in param


### PR DESCRIPTION
Fix for error like:
```
2023-11-01 12:25:03,214 panda.log.DBProxy: ERROR    updateJobStatus <PandaID=6006139656> : IndexError Replacement index 2 out of range for positional arg
s tuple Traceback (most recent call last):
  File "/opt/panda/lib/python3.10/site-packages/pandaserver/taskbuffer/OraDBProxy.py", line 2679, in updateJobStatus
    tmp_log.debug("skip to change {1} to {2} not to return to active".format(oldJobStatus, jobStatus))
IndexError: Replacement index 2 out of range for positional args tuple
```
