### PR TITLE
[ATLASPANDA-869] Upgrading snakemake to the last working version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ setup(
         "ruamel.yaml",
         "cwl-utils>=0.13",
         "packaging",
-        "snakemake==6.15.5",
+        "snakemake==7.30.1",
         "numpy",
         "scipy",
         "werkzeug",


### PR DESCRIPTION
[ATLASPANDA-869] Upgrading snakemake to the last working version. 

Anything newer than 7.30.1 requires refactoring of the panda-server code. 

Will work on refactoring it to be able to use the latest version (8.2.0).