### PR TITLE
Bring back DDMHandler.py as it is needed by JEDI. Change finisher.py to work with callbacks for _sub dataset

### DIFF
--- a/pandaserver/dataservice/DDMHandler.py
+++ b/pandaserver/dataservice/DDMHandler.py
@@ -1,0 +1,55 @@
+"""
+master hander for DDM
+"""
+
+import re
+import threading
+
+from pandacommon.pandalogger.LogWrapper import LogWrapper
+from pandacommon.pandalogger.PandaLogger import PandaLogger
+from pandaserver.dataservice.Activator import Activator
+from pandaserver.dataservice.finisher import Finisher
+
+# logger
+_logger = PandaLogger().getLogger("DDMHandler")
+
+
+class DDMHandler(threading.Thread):
+    # constructor
+    def __init__(self, taskBuffer, vuid, site=None, dataset=None, scope=None):
+        threading.Thread.__init__(self)
+        self.vuid = vuid
+        self.taskBuffer = taskBuffer
+        self.site = site
+        self.scope = scope
+        self.dataset = dataset
+
+    # main
+    def run(self):
+        # get logger
+        tmpLog = LogWrapper(
+            _logger,
+            f"<vuid={self.vuid} site={self.site} name={self.dataset}>",
+        )
+        # query dataset
+        tmpLog.debug("start")
+        if self.vuid is not None:
+            dataset = self.taskBuffer.queryDatasetWithMap({"vuid": self.vuid})
+        else:
+            dataset = self.taskBuffer.queryDatasetWithMap({"name": self.dataset})
+        if dataset is None:
+            tmpLog.error("Not found")
+            tmpLog.debug("end")
+            return
+        tmpLog.debug(f"type:{dataset.type} name:{dataset.name}")
+        if dataset.type == "dispatch":
+            # activate jobs in jobsDefined
+            Activator(self.taskBuffer, dataset).start()
+        if dataset.type == "output":
+            if dataset.name is not None and re.search("^panda\..*_zip$", dataset.name) is not None:
+                # start unmerge jobs
+                Activator(self.taskBuffer, dataset, enforce=True).start()
+            else:
+                # finish transferring jobs
+                Finisher(self.taskBuffer, dataset, site=self.site).start()
+        tmpLog.debug("end")

--- a/pandaserver/dataservice/finisher.py
+++ b/pandaserver/dataservice/finisher.py
@@ -162,7 +162,7 @@ class Finisher(threading.Thread):
                 # set flag for T2 cleanup
                 self.dataset.status = "cleanup"
                 self.task_buffer.updateDatasets([self.dataset])
-                jobs = self.task_buffer.peekJobs(ids, fromDefined=False, fromArchived=False, fromWaiting=False)
+                jobs = self.task_buffer.peekJobs(panda_ids, fromDefined=False, fromArchived=False, fromWaiting=False)
 
             tmp_log.debug(f"IDs: {panda_ids}")
             if len(panda_ids) != 0:

--- a/pandaserver/dataservice/finisher.py
+++ b/pandaserver/dataservice/finisher.py
@@ -152,13 +152,20 @@ class Finisher(threading.Thread):
                              f"run-{datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat('/')}")
         # start
         try:
-            tmp_log.debug(f"start: {self.job.PandaID}")
-            # update input files
-            panda_ids = [self.job.PandaID]
+            if self.job is not None:
+                tmp_log.debug(f"start: {self.job.PandaID}")
+                panda_ids = [self.job.PandaID]
+                jobs = [self.job]
+            else:
+                tmp_log.debug(f"start: {self.dataset.name}")
+                panda_ids = self.task_buffer.updateOutFilesReturnPandaIDs(self.dataset.name)
+                # set flag for T2 cleanup
+                self.dataset.status = "cleanup"
+                self.task_buffer.updateDatasets([self.dataset])
+                jobs = self.task_buffer.peekJobs(ids, fromDefined=False, fromArchived=False, fromWaiting=False)
+
             tmp_log.debug(f"IDs: {panda_ids}")
             if len(panda_ids) != 0:
-                # get job
-                jobs = [self.job]
                 # loop over all jobs
                 for job in jobs:
                     if job is None or job.jobStatus != "transferring":

--- a/pandaserver/taskbuffer/TaskBuffer.py
+++ b/pandaserver/taskbuffer/TaskBuffer.py
@@ -1843,6 +1843,18 @@ class TaskBuffer:
         # return
         return retVal
 
+    # update output files and return corresponding PandaIDs
+    def updateOutFilesReturnPandaIDs(self, dataset, fileLFN=""):
+        # get DBproxy
+        proxy = self.proxyPool.getProxy()
+        retList = []
+        # query PandaID
+        retList = proxy.updateOutFilesReturnPandaIDs(dataset, fileLFN)
+        # release proxy
+        self.proxyPool.putProxy(proxy)
+        # return
+        return retList
+
     # get datasets associated with file
     def getDatasetWithFile(self, lfn, jobPrioity=0):
         # get DBproxy


### PR DESCRIPTION
Bring back DDMHandler.py as it is needed by JEDI. Change finisher.py to be able to work with callbacks for _sub dataset so that jobs associated with _sub datasets can finish in one-go.