### PR TITLE
Fix trf

### DIFF
--- a/PandaPkgInfo.py
+++ b/PandaPkgInfo.py
@@ -1,1 +1,1 @@
-release_version = "0.3.9"
+release_version = "0.3.10"


### PR DESCRIPTION
Bump version to 0.3.10 since filename for 0.3.9 already exists in pypi