### PR TITLE
[ATLASPANDA-1271] Fix support over OIDC for vo.XXX.ZZZ named VOs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,8 @@ RUN mkdir /tmp/panda-wnscript && cd /tmp/panda-wnscript && \
     cp -R panda-wnscript/dist/* /var/trf/user/ && \
     cd / && rm -rf /tmp/panda-wnscript
 
+COPY /opt/panda/etc/panda/auth/vo.darkside.org_auth_config.json /opt/panda/etc/panda/auth/vo.darkside.org:_auth_config.json    
+
 ENV PANDA_LOCK_DIR /var/run/panda
 RUN mkdir -p ${PANDA_LOCK_DIR} && chmod 777 ${PANDA_LOCK_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,11 +121,11 @@ RUN mkdir /tmp/panda-wnscript && cd /tmp/panda-wnscript && \
     git clone https://github.com/PanDAWMS/panda-wnscript.git && \
     cp -R panda-wnscript/dist/* /var/trf/user/ && \
     cd / && rm -rf /tmp/panda-wnscript
-
-COPY /opt/panda/etc/panda/auth/vo.darkside.org_auth_config.json /opt/panda/etc/panda/auth/vo.darkside.org:_auth_config.json    
-
+    
 ENV PANDA_LOCK_DIR /var/run/panda
 RUN mkdir -p ${PANDA_LOCK_DIR} && chmod 777 ${PANDA_LOCK_DIR}
+
+COPY /opt/panda/etc/panda/auth/vo.darkside.org_auth_config.json /opt/panda/etc/panda/auth/vo.darkside.org:_auth_config.json    
 
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,8 +125,6 @@ RUN mkdir /tmp/panda-wnscript && cd /tmp/panda-wnscript && \
 ENV PANDA_LOCK_DIR /var/run/panda
 RUN mkdir -p ${PANDA_LOCK_DIR} && chmod 777 ${PANDA_LOCK_DIR}
 
-COPY /opt/panda/etc/panda/auth/vo.darkside.org_auth_config.json /opt/panda/etc/panda/auth/vo.darkside.org:_auth_config.json    
-
 CMD exec /bin/bash -c "trap : TERM INT; sleep infinity & wait"
 
 EXPOSE 25080 25443

--- a/pandaserver/config/panda_config.py
+++ b/pandaserver/config/panda_config.py
@@ -124,13 +124,23 @@ try:
                     data_dict[tmp_id] = data
         m = re.search("^(.+)_auth_config.json", os.path.basename(name))
         if m:
+            # Extract the VO group from the filename
             tmp_vo_group = m.group(1)
-            if ":" in tmp_vo_group:
-                tmp_vo, tmp_group = tmp_vo_group.split(":")[:2]
+
+            # Determine tmp_vo and tmp_group based on delimiters
+            if tmp_vo_group.startswith("vo.") and ":" in tmp_vo_group:
+                tmp_vo, tmp_group = tmp_vo_group.split(":", 1)
+            elif ":" in tmp_vo_group:
+                tmp_vo, tmp_group = tmp_vo_group.split(":", 1)
+            elif tmp_vo_group.startswith("vo."):
+                # If it starts with "vo." but has no ":", treat it as a single VO with "user" as the group
+                tmp_vo = tmp_vo_group
+                tmp_group = "user"
             elif "." in tmp_vo_group:
-                tmp_vo, tmp_group = tmp_vo_group.split(".")[:2]
+                tmp_vo, tmp_group = tmp_vo_group.split(".", 1)
             else:
                 tmp_vo, tmp_group = tmp_vo_group, "user"
+
             policy_dict.setdefault(tmp_vo, [])
             policy_dict[tmp_vo].append([tmp_vo, {"group": tmp_group, "role": tmp_group}])
             vo_data_dict[tmp_vo_group.replace(":", ".")] = data

--- a/pandaserver/srvcore/panda_request.py
+++ b/pandaserver/srvcore/panda_request.py
@@ -36,14 +36,17 @@ def decode_token(serialized_token, env, tmp_log):
             # extract role
             if vo:
                 if ":" in token["vo"]:
-                    # vo:role
-                    vo, role = token["vo"].split(":")
+                    # Use ':' as the separator for vo and role
+                    vo, role = token["vo"].split(":", 1)
                 else:
-                    # vo.role
-                    vo = token["vo"].split(".")[0]
-                    if vo != token["vo"]:
-                        role = token["vo"].split(":")[-1]
-                        role = role.split(".")[-1]
+                    # Use '.' as the separator for vo.role, assuming last part is the role
+                    parts = token["vo"].split(".")
+                    if len(parts) > 1:
+                        vo = ".".join(parts[:-1])  # All parts except the last one are vo
+                        role = parts[-1]  # Last part is the role
+                    else:
+                        vo = token["vo"]  # Single part, no role
+                        role = None
             # check vo
             if vo not in panda_config.auth_policies:
                 message_str = f"Unknown vo : {vo}"

--- a/pandaserver/srvcore/panda_request.py
+++ b/pandaserver/srvcore/panda_request.py
@@ -36,6 +36,7 @@ def decode_token(serialized_token, env, tmp_log):
             # extract role
             if "vo" in token:
                 vo_raw = token["vo"]  # Original input value of vo
+                tmp_log.debug(f"Raw VO from token: {vo_raw}")
 
                 if vo_raw.startswith("vo."):
                     # Handle vo names starting with "vo."
@@ -52,8 +53,12 @@ def decode_token(serialized_token, env, tmp_log):
                         vo, role = parts[0], parts[1]
                     else:
                         vo, role = vo_raw, None  # Single part, no role
+
+            tmp_log.debug(f"Parsed VO: {vo}, role: {role}")
+
             # check vo
             if vo not in panda_config.auth_policies:
+                tmp_log.error(f"VO '{vo}' not found in auth_policies: {list(panda_config.auth_policies.keys())}")
                 message_str = f"Unknown vo : {vo}"
             else:
                 # robot


### PR DESCRIPTION
Fix support for OIDC vo.XXX.ZZZ named VOs

    Currently vo.darkside.org is parsed into the following wrong VOs: ['vo', 'darskide']
    panda_config.auth_policies = ['vo', 'darkside']

To be able to support VOs starting with vo.* with or without a role defined (with :, so for example vo.darkside.org:production or vo.darkside.org) and to continue supporting VOs with . as the split between VO and role (so for example atlas.production, rubin.production and etc) if defined - otherwise it's atlas, rubin and etc (no delimiter to split VO and role).

I have kept the debugging messages, I could remove them if they are no longer needed.