### PR TITLE
Keep only rucio-clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ COPY . .
 # install panda-common first to prevent panda-client from installing redundant files
 RUN /opt/panda/bin/pip install --no-cache-dir panda-common
 RUN /opt/panda/bin/pip install --no-cache-dir .[postgres,oracle]
-RUN /opt/panda/bin/pip install --no-cache-dir rucio
 RUN /opt/panda/bin/pip install --no-cache-dir rucio-clients
 RUN /opt/panda/bin/pip install --no-cache-dir "git+https://github.com/PanDAWMS/panda-cacheschedconfig.git"
 RUN ln -s /opt/panda/lib/python*/site-packages/mod_wsgi/server/mod_wsgi*.so /etc/httpd/modules/mod_wsgi.so


### PR DESCRIPTION
According to Dimitrios the problem was fixed in 37.5.0, so pip3 install --upgrade rucio-clients==37.5.0 should fix the issue. 
