### PR TITLE
Fix hardcoded US cloud fallback in SiteMapper.getCloud()

### DIFF
--- a/pandaserver/brokerage/SiteMapper.py
+++ b/pandaserver/brokerage/SiteMapper.py
@@ -285,12 +285,8 @@ class SiteMapper:
         if cloud == WORLD_CLOUD:
             return self.worldCloudSpec
 
-        # return some default sites
-        default_cloud = {
-            "source": "default",
-            "sites": self.cloudSpec["US"]["sites"],
-        }
-        return default_cloud
+        # return all sites (WORLD) as fallback for unknown clouds
+        return self.worldCloudSpec
 
     # accessor for cloud
     def checkCloud(self, cloud):


### PR DESCRIPTION
## Summary
- `SiteMapper.getCloud()` was falling back to US cloud sites for any unrecognised cloud name
- This caused failures for experiments with no US cloud configured (e.g. SKA, vo.darkside.org)
- Fix: fall back to WORLD cloud instead, which contains all production sites and enables opportunistic execution

## Test plan
- [ ] Verify that tasks from VOs with no US cloud (SKA, vo.darkside.org) are brokered correctly to available sites
- [ ] Verify that existing ATLAS/US cloud behaviour is unchanged