### PR TITLE
fix(docker): remove default httpd ssl.conf that conflicts with panda SSL config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN /opt/panda/bin/pip install --no-cache-dir .[postgres,oracle,mcp]
 RUN /opt/panda/bin/pip install --no-cache-dir rucio-clients
 RUN /opt/panda/bin/pip install --no-cache-dir "git+https://github.com/PanDAWMS/panda-cacheschedconfig.git"
 RUN ln -s /opt/panda/lib/python*/site-packages/mod_wsgi/server/mod_wsgi*.so /etc/httpd/modules/mod_wsgi.so
+# Remove the default OS ssl.conf which references a non-existent localhost.crt and conflicts with panda's SSL config
+RUN rm -f /etc/httpd/conf.d/ssl.conf
 
 WORKDIR /
 RUN rm -rf /tmp/src


### PR DESCRIPTION
## Problem

The OS `httpd` package installs `/etc/httpd/conf.d/ssl.conf` inside the container image. This file references `/etc/pki/tls/certs/localhost.crt` which does not exist in the container:

```
SSLCertificateFile: file '/etc/pki/tls/certs/localhost.crt' does not exist or is empty
AH02312: Fatal error initialising mod_ssl, exiting.
```

Apache loads all files in `/etc/httpd/conf.d/` alphabetically, so the default `ssl.conf` is processed before panda's own SSL configuration and causes an immediate crash — leaving the server unable to serve HTTPS on port 25443.

## Why it wasn't caught sooner

The panda-server pod in the ATLAS testbed ran continuously for ~659 days without being rescheduled. Any **fresh pod start** (e.g. after force-deleting a pod stuck on a NotReady node) triggers this failure.

## Fix

Remove `ssl.conf` during the Docker image build. Panda's own SSL configuration (`panda_server-httpd.conf`) fully handles TLS; the OS default adds nothing and actively breaks startup.