### PR TITLE
fix(db): uppercase ATLAS_PANDA schema prefix in SQL to enable testbed substitution

### DIFF
--- a/pandaserver/daemons/scripts/hs_scrapers.py
+++ b/pandaserver/daemons/scripts/hs_scrapers.py
@@ -49,7 +49,7 @@ class BaseHS06Scraper:
 
     def _insert_cpu_perf_rows(self, rows: list[dict], source_url: str) -> None:
         sql = (
-            "INSERT INTO atlas_panda.cpu_benchmarks "
+            "INSERT INTO ATLAS_PANDA.cpu_benchmarks "
             "(cpu_type, cpu_type_normalized, smt_enabled, ncores, site, score_per_core, source) "
             "VALUES (:cpu_type, :cpu_type_normalized, :smt_enabled, :ncores, :site, :score_per_core, :source)"
         )
@@ -201,7 +201,7 @@ class HS23Ingestor:
         return out
 
     def _select_max_timestamp(self, df: pl.DataFrame) -> None:
-        sql = "SELECT max(timestamp) FROM atlas_panda.cpu_benchmarks"
+        sql = "SELECT max(timestamp) FROM ATLAS_PANDA.cpu_benchmarks"
         status, res = self.task_buffer.querySQLS(sql, {})
         max_timestamp = res[0][0]
         if not max_timestamp:
@@ -210,7 +210,7 @@ class HS23Ingestor:
 
     def _insert(self, df: pl.DataFrame) -> None:
         sql = (
-            "INSERT INTO atlas_panda.cpu_benchmarks "
+            "INSERT INTO ATLAS_PANDA.cpu_benchmarks "
             "(cpu_type, cpu_type_normalized, smt_enabled, sockets, cores_per_socket, ncores, site, "
             "score_per_core, timestamp, source) "
             "VALUES (:cpu_type, :cpu_type_normalized, :smt_enabled, :sockets, :cores_per_socket, :ncores, "

--- a/pandaserver/taskbuffer/db_proxy_mods/entity_module.py
+++ b/pandaserver/taskbuffer/db_proxy_mods/entity_module.py
@@ -2745,10 +2745,10 @@ class EntityModule(BaseModule):
             sql_last = (
                 "WITH top_ts(timestamp, region) AS "
                 "(SELECT max(timestamp), region "
-                "FROM atlas_panda.carbon_region_emissions "
+                "FROM ATLAS_PANDA.carbon_region_emissions "
                 "GROUP BY region) "
                 "SELECT cre.region, cre.value, cre.timestamp "
-                "FROM atlas_panda.carbon_region_emissions cre, top_ts "
+                "FROM ATLAS_PANDA.carbon_region_emissions cre, top_ts "
                 "WHERE cre.timestamp = top_ts.timestamp AND cre.region = top_ts.region"
             )
 
@@ -3687,7 +3687,7 @@ class EntityModule(BaseModule):
 
         sql = """
         SELECT pdr.panda_site_name, de.site_name, nvl(pdr.scope, 'default')
-        FROM atlas_panda.panda_ddm_relation pdr, atlas_panda.ddm_endpoint de
+        FROM ATLAS_PANDA.panda_ddm_relation pdr, ATLAS_PANDA.ddm_endpoint de
         WHERE pdr.default_write = 'Y'
         AND pdr.ddm_endpoint_name = de.ddm_endpoint_name
         """

--- a/pandaserver/taskbuffer/db_proxy_mods/misc_standalone_module.py
+++ b/pandaserver/taskbuffer/db_proxy_mods/misc_standalone_module.py
@@ -229,7 +229,7 @@ class MiscStandaloneModule(BaseModule):
         # See if there are successful jobs for this task. If yes, skip this method
         sql = (
             f"SELECT 1 FROM "
-            f"(SELECT 1 FROM atlas_panda.jobsarchived4 "
+            f"(SELECT 1 FROM ATLAS_PANDA.jobsarchived4 "
             f"WHERE jeditaskid = :jedi_task_id AND jobstatus = 'finished' AND transformation NOT LIKE '%build%' AND ROWNUM = 1 "
             f"UNION ALL "
             f"SELECT 1 FROM atlas_pandaarch.jobsarchived "

--- a/pandaserver/taskbuffer/db_proxy_mods/worker_module.py
+++ b/pandaserver/taskbuffer/db_proxy_mods/worker_module.py
@@ -1918,7 +1918,7 @@ class WorkerModule(BaseModule):
 
         try:
             sql = (
-                "SELECT cb.site, score_per_core FROM atlas_panda.worker_node wn, atlas_panda.cpu_benchmarks cb "
+                "SELECT cb.site, score_per_core FROM ATLAS_PANDA.worker_node wn, ATLAS_PANDA.cpu_benchmarks cb "
                 "WHERE wn.site = :site "
                 "AND wn.host_name = :host_name "
                 "AND cb.cpu_type_normalized = wn.cpu_model_normalized "


### PR DESCRIPTION
## Summary

- `WrappedCursor.change_schema()` uses a **case-sensitive** regex `re.sub("ATLAS_PANDA\.", ...)` to rewrite schema prefixes for non-production deployments
- Four SQL statements used lowercase `atlas_panda.` instead of `ATLAS_PANDA.`, silently bypassing the substitution
- On the testbed (`INT8R`, `schemaPANDA=ATLAS_PANDA_TB`), the raw `atlas_panda.` prefix was sent to Oracle, causing `ORA-00942: table or view does not exist`
- This caused `getPandaSiteToOutputStorageSiteMapping()` to throw a `JEDIFatalError` on every brokerage attempt, leaving **managed production tasks permanently stuck in `assigning` status**

## Files changed

| File | Table(s) affected |
|---|---|
| `entity_module.py` | `panda_ddm_relation`, `ddm_endpoint`, `carbon_region_emissions` |
| `misc_standalone_module.py` | `jobsarchived4` |
| `worker_module.py` | `worker_node`, `cpu_benchmarks` |
| `hs_scrapers.py` | `cpu_benchmarks` |

## Fix

Uppercase the schema prefix in all four files: `atlas_panda.` → `ATLAS_PANDA.`

This is consistent with every other SQL statement in the codebase and allows `change_schema()` to correctly rewrite the prefix on testbed/non-production deployments.

## Test plan

- [ ] On testbed (INT8R, `schemaPANDA=ATLAS_PANDA_TB`): submit a managed production task and confirm it exits `assigning` → `running`
- [ ] On production (`schemaPANDA=ATLAS_PANDA`): `change_schema()` is a no-op when the schema matches the default, so no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)