### PR TITLE
give priority to rucio account as set in env vars

### DIFF
--- a/templates/sysconfig/panda_jedi.template
+++ b/templates/sysconfig/panda_jedi.template
@@ -13,7 +13,11 @@ fi
 # for Rucio
 export X509_CERT_DIR=/etc/grid-security/certificates
 export X509_USER_PROXY=/data/atlpan/x509up_u25606
-export RUCIO_ACCOUNT=panda
+if [[ -z "${PANDA_RUCIO_ACCOUNT}" ]]; then
+  export RUCIO_ACCOUNT=panda
+else
+  export RUCIO_ACCOUNT=${PANDA_RUCIO_ACCOUNT}
+fi
 export RUCIO_APPID=pandasrv
 
 # panda home

--- a/templates/sysconfig/panda_jedi_env.template
+++ b/templates/sysconfig/panda_jedi_env.template
@@ -12,7 +12,11 @@ PYTHONPATH=@@install_purelib@@/pandacommon:@@install_purelib@@/pandaserver
 # for Rucio
 X509_CERT_DIR=/etc/grid-security/certificates
 X509_USER_PROXY=/data/atlpan/x509up_u25606
-RUCIO_ACCOUNT=panda
+if [[ -z "${PANDA_RUCIO_ACCOUNT}" ]]; then
+	RUCIO_ACCOUNT=panda
+else
+	RUCIO_ACCOUNT=${PANDA_RUCIO_ACCOUNT}
+fi
 RUCIO_APPID=pandasrv
 
 # panda home


### PR DESCRIPTION
Fixes the setting of `RUCIO_ACCOUNT` made by `panda_jedi.template` and `panda_jedi_env.template`, based on the possibly-existing environment variable `PANDA_RUCIO_ACCOUNT`, as already done in `panda_server.sysconfig.rpmnew.template`