### PR TITLE
fix(db): uppercase schema prefixes in SQL for schema translation

### DIFF
--- a/pandaserver/taskbuffer/db_proxy_mods/misc_standalone_module.py
+++ b/pandaserver/taskbuffer/db_proxy_mods/misc_standalone_module.py
@@ -232,7 +232,7 @@ class MiscStandaloneModule(BaseModule):
             f"(SELECT 1 FROM ATLAS_PANDA.jobsarchived4 "
             f"WHERE jeditaskid = :jedi_task_id AND jobstatus = 'finished' AND transformation NOT LIKE '%build%' AND ROWNUM = 1 "
             f"UNION ALL "
-            f"SELECT 1 FROM atlas_pandaarch.jobsarchived "
+            f"SELECT 1 FROM ATLAS_PANDAARCH.jobsarchived "
             f"WHERE jeditaskid = :jedi_task_id AND jobstatus = 'finished' AND transformation NOT LIKE '%build%' AND ROWNUM = 1) "
             f"WHERE ROWNUM = 1"
         )


### PR DESCRIPTION
## Summary
- Fix lowercase `atlas_pandaarch.` schema prefix in `misc_standalone_module.py` — `WrappedCursor` only translates uppercase `ATLAS_PANDAARCH.` to `panda_config.schemaPANDAARCH`, so the lowercase form bypassed schema substitution entirely on non-Oracle backends (PostgreSQL/testbed)

## Test plan
- [ ] Verify schema substitution works on testbed (PostgreSQL) for the affected query in `misc_standalone_module.py:235`
- [ ] Confirm no regression on Oracle production