### PR TITLE
Use WN GPU monitoring as primary source for GPU brokerage attribute checks

### DIFF
--- a/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasAnalJobBroker.py
@@ -47,6 +47,13 @@ class AtlasAnalJobBroker(JobBrokerBase):
             logger.error("Failed to load the WN architecture level map!!!")
             self.architecture_level_map = {}
 
+        # load the worker node GPU map
+        try:
+            self.wn_gpu_map = taskBufferIF.get_worker_node_gpu_map()
+        except BaseException:
+            logger.error("Failed to load the WN GPU map!!!")
+            self.wn_gpu_map = {}
+
     # main
     def doBrokerage(self, taskSpec, cloudName, inputChunk, taskParamMap):
         # make logger
@@ -810,7 +817,7 @@ class AtlasAnalJobBroker(JobBrokerBase):
             newScanSiteList = []
             oldScanSiteList = copy.copy(scanSiteList)
             msg_map = {}
-            jsonCheck = AtlasBrokerUtils.JsonSoftwareCheck(self.siteMapper, self.sw_map, self.architecture_level_map)
+            jsonCheck = AtlasBrokerUtils.JsonSoftwareCheck(self.siteMapper, self.sw_map, self.architecture_level_map, self.wn_gpu_map)
             for tmpSiteName in scanSiteList:
                 tmpSiteSpec = self.siteMapper.getSite(tmpSiteName)
                 if tmpSiteSpec.isGPU() and not taskSpec.is_hpo_workflow():

--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -1136,6 +1136,14 @@ class JsonSoftwareCheck:
                                     for g in wn_gpus
                                 ):
                                     continue
+
+                            # check minimum GPU driver version (kernel driver, e.g. 575.57.08)
+                            if "driver_version" in host_gpu_spec:
+                                if not wn_gpus or not any(
+                                    g.get("driver_version") and compare_version_string(g["driver_version"], host_gpu_spec["driver_version"])
+                                    for g in wn_gpus
+                                ):
+                                    continue
                     go_ahead = True
                 except Exception as e:
                     if log_stream:

--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -959,10 +959,11 @@ def compare_version_string(version_string, comparison_string):
 # check SW with json
 class JsonSoftwareCheck:
     # constructor
-    def __init__(self, site_mapper, sw_map, wn_architecture_level_map):
+    def __init__(self, site_mapper, sw_map, wn_architecture_level_map, wn_gpu_map=None):
         self.siteMapper = site_mapper
         self.sw_map = sw_map
         self.wn_architecture_level_map = wn_architecture_level_map
+        self.wn_gpu_map = wn_gpu_map or {}
 
     # get lists
     def check(
@@ -1081,53 +1082,60 @@ class JsonSoftwareCheck:
 
                         # check GPU
                         if host_gpu_spec:
-                            # GPU not specified
+                            # CRIC is the GPU capability gate: skip queue if not GPU-capable per CRIC
                             if "gpu" not in architecture_map:
                                 continue
 
+                            # All attribute checks use WN GPU monitoring (MV_WORKER_NODE_GPU_SUMMARY)
+                            # which has richer per-host data (vram, architecture, driver version)
+                            wn_gpus = self.wn_gpu_map.get(tmp_site_name, [])
+
                             # check vendor
-                            if host_gpu_spec["vendor"] == "*":
-                                # task doesn't specify CPU vendor and PQ explicitly requests a specific vendor
-                                if "vendor" in architecture_map["gpu"] and "excl" in architecture_map["gpu"]["vendor"]:
-                                    continue
-                            else:
-                                # task specifies a vendor and PQ doesn't request any specific vendor
-                                if "vendor" not in architecture_map["gpu"]:
-                                    continue
-                                # task specifies a vendor and PQ doesn't accept any vendor or the specific vendor
-                                if "any" not in architecture_map["gpu"]["vendor"] and host_gpu_spec["vendor"] not in architecture_map["gpu"]["vendor"]:
+                            if host_gpu_spec["vendor"] != "*":
+                                if not wn_gpus or not any(
+                                    g.get("vendor") and re.match(host_gpu_spec["vendor"], g["vendor"], re.IGNORECASE)
+                                    for g in wn_gpus
+                                ):
                                     continue
 
-                            # check model
-                            if host_gpu_spec["model"] == "*":
-                                if "model" in architecture_map["gpu"] and "excl" in architecture_map["gpu"]["model"]:
-                                    continue
-                            else:
+                            # check model (include or exclude pattern)
+                            if host_gpu_spec["model"] != "*":
                                 if isinstance(host_gpu_spec["model"], dict):
                                     model_pattern = host_gpu_spec["model"]["pattern"]
                                     model_excl = host_gpu_spec["model"].get("excl", False)
                                 else:
                                     model_pattern = host_gpu_spec["model"]
                                     model_excl = False
-                                if "model" not in architecture_map["gpu"] or (
-                                    "any" not in architecture_map["gpu"]["model"]
-                                    and any(re.match(model_pattern, m, re.IGNORECASE) for m in architecture_map["gpu"]["model"])
-                                    == model_excl
-                                ):
+                                if not wn_gpus:
+                                    continue
+                                matches = any(
+                                    g.get("model") and re.match(model_pattern, g["model"], re.IGNORECASE)
+                                    for g in wn_gpus
+                                )
+                                if matches == model_excl:
                                     continue
 
-                            # check version
-                            if "version" in host_gpu_spec:
-                                if "version" not in architecture_map["gpu"]:
-                                    # PQ doesn't specify version
+                            # check minimum VRAM (in MB)
+                            if "vram" in host_gpu_spec:
+                                min_vram = host_gpu_spec["vram"]
+                                if not wn_gpus or not any(g.get("vram") and g["vram"] >= min_vram for g in wn_gpus):
                                     continue
-                                elif "any" == architecture_map["gpu"]["version"]:
-                                    # PQ accepts any version
-                                    pass
-                                else:
-                                    # check version at PQ
-                                    if not compare_version_string(architecture_map["gpu"]["version"], host_gpu_spec["version"]):
-                                        continue
+
+                            # check GPU microarchitecture generation (e.g. Ampere, Hopper, Ada Lovelace)
+                            if "architecture" in host_gpu_spec:
+                                req_arch = host_gpu_spec["architecture"]
+                                if isinstance(req_arch, str):
+                                    req_arch = [req_arch]
+                                if not wn_gpus or not any(g.get("architecture") in req_arch for g in wn_gpus):
+                                    continue
+
+                            # check minimum CUDA version
+                            if "version" in host_gpu_spec:
+                                if not wn_gpus or not any(
+                                    g.get("framework_version") and compare_version_string(g["framework_version"], host_gpu_spec["version"])
+                                    for g in wn_gpus
+                                ):
+                                    continue
                     go_ahead = True
                 except Exception as e:
                     if log_stream:

--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -1122,8 +1122,8 @@ class JsonSoftwareCheck:
                                     continue
 
                             # check GPU microarchitecture generation (e.g. Ampere, Hopper, Ada Lovelace)
-                            if "architecture" in host_gpu_spec:
-                                req_arch = host_gpu_spec["architecture"]
+                            if "microarchitecture" in host_gpu_spec:
+                                req_arch = host_gpu_spec["microarchitecture"]
                                 if isinstance(req_arch, str):
                                     req_arch = [req_arch]
                                 if not wn_gpus or not any(g.get("architecture") in req_arch for g in wn_gpus):

--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -1115,10 +1115,12 @@ class JsonSoftwareCheck:
                                 if matches == model_excl:
                                     continue
 
-                            # check minimum VRAM (in MB)
+                            # check VRAM (in MB); supports operators: ==, >=, <=, >, <, != (e.g. ">=40960")
                             if "vram" in host_gpu_spec:
-                                min_vram = host_gpu_spec["vram"]
-                                if not wn_gpus or not any(g.get("vram") and g["vram"] >= min_vram for g in wn_gpus):
+                                if not wn_gpus or not any(
+                                    g.get("vram") and compare_version_string(str(g["vram"]), host_gpu_spec["vram"])
+                                    for g in wn_gpus
+                                ):
                                     continue
 
                             # check GPU microarchitecture generation (e.g. Ampere, Hopper, Ada Lovelace)

--- a/pandajedi/jedibrokerage/AtlasProdJobBroker.py
+++ b/pandajedi/jedibrokerage/AtlasProdJobBroker.py
@@ -96,6 +96,13 @@ class AtlasProdJobBroker(JobBrokerBase):
             logger.error("Failed to load the WN architecture level map!!!")
             self.architecture_level_map = {}
 
+        # load the worker node GPU map
+        try:
+            self.wn_gpu_map = taskBufferIF.get_worker_node_gpu_map()
+        except BaseException:
+            logger.error("Failed to load the WN GPU map!!!")
+            self.wn_gpu_map = {}
+
     def convertMBpsToWeight(self, mbps):
         """
         Takes MBps value and converts to a weight between 1 and 2
@@ -754,7 +761,7 @@ class AtlasProdJobBroker(JobBrokerBase):
         resolved_platforms = {}
         preference_weight_map = {}
         if taskSpec.transHome is not None:
-            jsonCheck = AtlasBrokerUtils.JsonSoftwareCheck(self.siteMapper, self.sw_map, self.architecture_level_map)
+            jsonCheck = AtlasBrokerUtils.JsonSoftwareCheck(self.siteMapper, self.sw_map, self.architecture_level_map, self.wn_gpu_map)
             unified_site_list = self.get_unified_sites(scanSiteList)
 
             host_cpu_spec = taskSpec.get_host_cpu_spec()

--- a/pandaserver/taskbuffer/JediTaskSpec.py
+++ b/pandaserver/taskbuffer/JediTaskSpec.py
@@ -1414,9 +1414,27 @@ class JediTaskSpec(object):
             spec_str = m.group(1)
             if not spec_str:
                 return None
-            spec_str += "-*" * (1 - spec_str.count("-"))
-            items = spec_str.split("-")
+            # split into legacy vendor<-model> part and optional colon-separated key=value attributes
+            parts = spec_str.split(":")
+            legacy = parts[0]
+            legacy += "-*" * (1 - legacy.count("-"))
+            items = legacy.split("-")
             spec = {"vendor": items[0], "model": items[1]}
+            # parse extended attributes: cuda>=12.0, vram=40960, uarch=Ampere, driver>=575.0, model=.*A100.*
+            shorthand_map = {"cuda": "version", "uarch": "microarchitecture", "driver": "driver_version", "model": "model", "vram": "vram"}
+            for part in parts[1:]:
+                attr_m = re.match(r"(\w+)(>=|<=|!=|>|<|=)(.*)", part)
+                if not attr_m:
+                    continue
+                key, op, val = attr_m.group(1), attr_m.group(2), attr_m.group(3)
+                mapped = shorthand_map.get(key)
+                if not mapped:
+                    continue
+                if mapped == "model":
+                    spec["model"] = val
+                else:
+                    spec[mapped] = ("==" if op == "=" else op) + val
+
             return spec
         except Exception:
             return None

--- a/pandaserver/taskbuffer/TaskBuffer.py
+++ b/pandaserver/taskbuffer/TaskBuffer.py
@@ -774,6 +774,12 @@ class TaskBuffer:
             ret = proxy.get_architecture_level_map()
         return ret
 
+    def get_worker_node_gpu_map(self):
+        # get DB proxy
+        with self.proxyPool.get() as proxy:
+            ret = proxy.get_worker_node_gpu_map()
+        return ret
+
     # finalize pending analysis jobs
     def finalizePendingJobs(self, prodUserName, jobDefinitionID, waitLock=False):
         # get DB proxy

--- a/pandaserver/taskbuffer/db_proxy_mods/worker_module.py
+++ b/pandaserver/taskbuffer/db_proxy_mods/worker_module.py
@@ -1401,6 +1401,42 @@ class WorkerModule(BaseModule):
             self.dump_error_message(tmp_log)
             return {}
 
+    def get_worker_node_gpu_map(self):
+        comment = " /* DBProxy.get_worker_node_gpu_map */"
+        tmp_log = self.create_tagged_logger(comment)
+        tmp_log.debug("Start")
+
+        try:
+            sql = (
+                "SELECT panda_queue, vendor, model, vram, architecture, framework_version, driver_version, gpus_per_host "
+                "FROM ATLAS_PANDA.MV_WORKER_NODE_GPU_SUMMARY "
+            )
+            self.cur.execute(sql + comment, {})
+            results = self.cur.fetchall()
+
+            tmp_log.debug(f"Got {len(results)} entries from MV_WORKER_NODE_GPU_SUMMARY")
+
+            gpu_map = {}
+            for panda_queue, vendor, model, vram, architecture, framework_version, driver_version, gpus_per_host in results:
+                gpu_map.setdefault(panda_queue, []).append(
+                    {
+                        "vendor": vendor,
+                        "model": model,
+                        "vram": vram,
+                        "architecture": architecture,
+                        "framework_version": framework_version,
+                        "driver_version": driver_version,
+                        "gpus_per_host": gpus_per_host,
+                    }
+                )
+
+            tmp_log.debug("Done")
+            return gpu_map
+
+        except Exception:
+            self.dump_error_message(tmp_log)
+            return {}
+
     # get workers for a job
     def getWorkersForJob(self, PandaID):
         comment = " /* DBProxy.getWorkersForJob */"


### PR DESCRIPTION
## Summary

- CRIC is now used **only as a GPU capability gate**: if a queue has `"gpu"` in its CRIC architecture map it is considered GPU-capable; otherwise it is skipped immediately
- All GPU **attribute checks** (vendor, model, vram, architecture, CUDA version) are performed against `MV_WORKER_NODE_GPU_SUMMARY` (WN GPU monitoring), which has richer per-host data than CRIC
- New `get_worker_node_gpu_map()` DB method + TaskBuffer wrapper to load the MV at broker init
- New supported filters in `host_gpu_spec` (task `--architecture` JSON):
  - `vram`: minimum VRAM in MB (e.g. `40960`)
  - `architecture`: GPU microarch generation or list (e.g. `"Ampere"` or `["Ampere", "Hopper"]`)
  - `version`: minimum CUDA version — existing filter, now sourced from WN map `framework_version`

## Motivation

ATLASPANDA-1684 + Fernando's suggestion to use `MV_WORKER_NODE_GPU_SUMMARY` as a fallback/primary source for GPU brokerage. Previous approach relied entirely on CRIC, which often lacks model info, vram, and driver version for many GPU queues. WN monitoring data is populated directly by pilots and is more complete and up to date.

Requires the companion panda-database PR to add `ARCHITECTURE` and `DRIVER_VERSION` columns to the MV.

## Test plan

- [ ] Verify queues not marked GPU in CRIC are skipped without querying WN map
- [ ] Verify model include/exclude pattern matching works against WN map models
- [ ] Verify `vram` filter correctly rejects queues below the threshold
- [ ] Verify `architecture` filter (e.g. `["Ampere", "Hopper"]`) routes to correct queues
- [ ] Verify CUDA `version` filter uses `framework_version` from WN map
- [ ] Verify queues GPU-capable in CRIC but absent from WN map: wildcard task passes, specific-attribute task fails