### PR TITLE
Fix == operator in GPU shorthand being parsed as ===

### DIFF
--- a/pandaserver/taskbuffer/JediTaskSpec.py
+++ b/pandaserver/taskbuffer/JediTaskSpec.py
@@ -1423,7 +1423,7 @@ class JediTaskSpec(object):
             # parse extended attributes: cuda>=12.0, vram=40960, uarch=Ampere, driver>=575.0, model=.*A100.*
             shorthand_map = {"cuda": "version", "uarch": "microarchitecture", "driver": "driver_version", "model": "model", "vram": "vram"}
             for part in parts[1:]:
-                attr_m = re.match(r"(\w+)(>=|<=|!=|>|<|=)(.*)", part)
+                attr_m = re.match(r"(\w+)(>=|<=|!=|==|>|<|=)(.*)", part)
                 if not attr_m:
                     continue
                 key, op, val = attr_m.group(1), attr_m.group(2), attr_m.group(3)


### PR DESCRIPTION
## Summary

- In the shorthand GPU spec parser (`JediTaskSpec.get_host_gpu_spec`), the regex alternation `(>=|<=|!=|>|<|=)` matched single `=` before `==`
- As a result, `driver==575.51.03` was parsed as `op='='`, `val='=575.51.03'`, then the `"==" if op == "="` normalisation produced `===575.51.03` — an invalid operator that never matched anything
- Fix: add `==` to the alternation before `=` so double-equals is captured as a single token

## Test plan

- [ ] `#&nvidia:driver==575.51.03` now correctly produces `driver_version: '==575.51.03'` and matches sites with exactly that driver version
- [ ] `#&nvidia:driver=575.51.03` (single `=`) continues to work as before
- [ ] All other operators (`>=`, `<=`, `!=`, `>`, `<`) unaffected