### PR TITLE
Fix microarchitecture shorthand storing ==Ampere instead of Ampere

### DIFF
--- a/pandaserver/taskbuffer/JediTaskSpec.py
+++ b/pandaserver/taskbuffer/JediTaskSpec.py
@@ -1430,8 +1430,8 @@ class JediTaskSpec(object):
                 mapped = shorthand_map.get(key)
                 if not mapped:
                     continue
-                if mapped == "model":
-                    spec["model"] = val
+                if mapped in ("model", "microarchitecture"):
+                    spec[mapped] = val
                 else:
                     spec[mapped] = ("==" if op == "=" else op) + val
 


### PR DESCRIPTION
## Summary

- The shorthand parser (`JediTaskSpec.get_host_gpu_spec`) prepended `==` to all non-model attribute values
- For `uarch=Ampere`, this produced `microarchitecture: '==Ampere'` in the gpu_spec
- The brokerage checks microarchitecture with a plain `in` membership test (`g.get("architecture") in req_arch`), not with `compare_version_string`, so `'==Ampere'` never matched `'Ampere'` from the WN GPU map — all sites were rejected
- Fix: treat `microarchitecture` like `model` and store the value as-is, without operator prefix

## Test plan

- [ ] `#&nvidia:uarch=Ampere` now produces `microarchitecture: 'Ampere'` and correctly matches Ampere GPU sites
- [ ] JSON format `{"gpu_spec": {"vendor": "nvidia", "microarchitecture": "Ampere"}}` was already correct (unaffected)
- [ ] `vram`, `version`, `driver_version` operator-prefixed values unaffected