### PR TITLE
Treat single = as == in GPU version comparisons for JSON gpu_spec

### DIFF
--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -932,6 +932,8 @@ def compare_version_string(version_string, comparison_string):
         return None
 
     operator = match.group(1).strip()
+    if operator == "=":
+        operator = "=="
     version_to_compare = match.group(2).strip()
 
     try:


### PR DESCRIPTION
When specifying GPU constraints via JSON, users can write operator-prefixed strings such as \"=15360\" (single equals) expecting exact-match behaviour, consistent with how single = works in the shorthand syntax.

The shorthand parser in JediTaskSpec.py already normalises = to == before storing the spec. However, the JSON path passes the string through unchanged, and compare_version_string only recognises == (double equals) as exact match — a bare = falls through to return None, causing every site to fail the check and the task to get no brokerage.

The fix normalises = to == at the top of compare_version_string, making the JSON and shorthand paths consistent. This affects vram, version (CUDA), and driver_version checks.