### PR TITLE
Build and push latest Docker image on every merge to main

### DIFF
--- a/.github/workflows/panda-server-docker-publish.yml
+++ b/.github/workflows/panda-server-docker-publish.yml
@@ -6,6 +6,9 @@ name: Docker - Publish PanDA Server Image
 # documentation.
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [published]
   workflow_dispatch:
@@ -46,6 +49,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
Currently the Docker image is only built when a GitHub release is published. This means the testbed always lags behind main until someone manually cuts a release.

This change adds a push-to-main trigger so the image is built and pushed as `latest` on every merge to main. Releases continue to produce version-tagged images (e.g. `1.0.0`) alongside `latest`, so nothing changes for production deployments that pin to a specific tag.

The `type=raw,value=latest,enable={{is_default_branch}}` tag rule ensures `latest` is only pushed from the default branch, not from other branches or forks.