### PR TITLE
Fix Docker build trigger to watch master branch

### DIFF
--- a/.github/workflows/panda-server-docker-publish.yml
+++ b/.github/workflows/panda-server-docker-publish.yml
@@ -8,7 +8,7 @@ name: Docker - Publish PanDA Server Image
 on:
   push:
     branches:
-      - main
+      - master
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
The push-to-master Docker build trigger added in #724 used branch name 'main', but the default branch of this repository is 'master'. As a result the trigger never fired.