### PR TITLE
Support model exclusion in GPU brokerage shorthand syntax

### DIFF
--- a/pandaserver/taskbuffer/JediTaskSpec.py
+++ b/pandaserver/taskbuffer/JediTaskSpec.py
@@ -1430,7 +1430,9 @@ class JediTaskSpec(object):
                 mapped = shorthand_map.get(key)
                 if not mapped:
                     continue
-                if mapped in ("model", "microarchitecture"):
+                if mapped == "model":
+                    spec[mapped] = {"pattern": val, "excl": True} if op == "!=" else val
+                elif mapped == "microarchitecture":
                     spec[mapped] = val
                 else:
                     spec[mapped] = ("==" if op == "=" else op) + val


### PR DESCRIPTION
Implements ATLASPANDA-1767.

The shorthand GPU brokerage format (`#&nvidia:key=value`) already handled `!=` for numeric fields (vram, driver, cuda) but silently ignored the operator for `model`, always treating it as inclusion. This change wires `model!=` to produce `{"pattern": val, "excl": True}`, consistent with how the existing JSON format expresses model exclusion.

Users can now write:

```
# exclude P100 queues
prun --architecture '#&nvidia:model!=.*P100.*' ...

# exclude P100 or V100 queues
prun --architecture '#&nvidia:model!=.*(P100|V100).*' ...
```

instead of the more verbose JSON equivalent:

```
prun --architecture '{"gpu_spec": {"vendor": "nvidia", "model": {"pattern": ".*(P100|V100).*", "excl": true}}}' ...
```

The change is a 3-line addition in `get_host_gpu_spec()` — no impact on existing `model=` inclusion behaviour or any other field.