### PR TITLE
Fix subquery alias errors in duplicateFilesForReuse_JEDI on PostgreSQL

### DIFF
--- a/pandaserver/taskbuffer/db_proxy_mods/task_utils_module.py
+++ b/pandaserver/taskbuffer/db_proxy_mods/task_utils_module.py
@@ -1645,7 +1645,7 @@ class TaskUtilsModule(BaseModule):
             sqlCT += "SELECT distinct lfn,startEvent,endEvent "
             sqlCT += f"FROM {panda_config.schemaJEDI}.JEDI_Dataset_Contents "
             sqlCT += "WHERE jediTaskID=:jediTaskID AND datasetID=:datasetID "
-            sqlCT += ") "
+            sqlCT += ") t "
             # sql to read file spec
             defaultVales = {}
             defaultVales["status"] = "ready"
@@ -1663,9 +1663,9 @@ class TaskUtilsModule(BaseModule):
             sqlFR += "WHERE jediTaskID=:jediTaskID AND datasetID=:datasetID "
             sqlFR += "GROUP BY lfn,startEvent,endEvent) "
             if not datasetSpec.isRandom():
-                sqlFR += "ORDER BY fileID) "
+                sqlFR += "ORDER BY fileID) t "
             else:
-                sqlFR += "ORDER BY DBMS_RANDOM.value) "
+                sqlFR += "ORDER BY DBMS_RANDOM.value) t "
             # sql to update dataset record
             sqlDU = f"UPDATE {panda_config.schemaJEDI}.JEDI_Datasets "
             sqlDU += "SET nFiles=nFiles+:iFiles,nFilesTobeUsed=nFilesTobeUsed+:iFiles "


### PR DESCRIPTION
Fixes a PostgreSQL-specific SQL error reported when running JEDI task processing:

```
SyntaxError: subquery in FROM must have an alias
LINE 1: SELECT COUNT(*) FROM (SELECT distinct lfn,startEvent,endEven...
HINT:  For example, FROM (SELECT ...) [AS] foo.
```

PostgreSQL requires all subqueries in `FROM` clauses to have an alias; Oracle does not. Two subqueries in `duplicateFilesForReuse_JEDI` were missing the alias:

1. The `COUNT(*)` query used to count unique files before insertion
2. The `INSERT ... SELECT ... FROM (...)` query used to duplicate the file records

`DBMS_RANDOM.value` is left unchanged — `WrappedCursor.convert_query_in_printf_format` already translates it to `RANDOM()` for PostgreSQL backends.