### PR TITLE
Bump release version to 1.0.1

### DIFF
--- a/PandaPkgInfo.py
+++ b/PandaPkgInfo.py
@@ -1,1 +1,1 @@
-release_version = "1.0.0"
+release_version = "1.0.1"


### PR DESCRIPTION
Bumps PandaPkgInfo.py to 1.0.1 to match the tag created for the PostgreSQL subquery alias fix (#743).