### PR TITLE
Updating dependency to capture latest panda-common tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "PanDA Team", email = "panda-support@cern.ch" },
 ]
 dependencies = [
-    'panda-common>=0.1.8',
+    'panda-common>=0.1.9',
     'panda-client-light>=1.5.55',
     'pyOpenSSL',
     'python-daemon',


### PR DESCRIPTION
With panda-server tag 1.0.1, I get errors like this:
```
Process Process-20:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/panda/lib/python3.11/site-packages/pandajedi/jediorder/JediMaster.py", line 29, in launcher
    mod = __import__(moduleName)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/panda/lib/python3.11/site-packages/pandajedi/jediorder/JediMsgProcessor.py", line 2, in <module>
    from pandacommon.pandamsgbkr import msg_processor
  File "/opt/panda/lib/python3.11/site-packages/pandacommon/pandamsgbkr/msg_processor.py", line 14, in <module>
    from .msg_bkr_utils import MBListenerProxy, MBSenderProxy, MsgBuffer
  File "/opt/panda/lib/python3.11/site-packages/pandacommon/pandamsgbkr/msg_bkr_utils.py", line 24, in <module>
    stomp_logger = stomp.logging.__logger
                   ^^^^^^^^^^^^^
AttributeError: module 'stomp' has no attribute 'logging'
Process Process-20:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/panda/lib/python3.11/site-packages/pandajedi/jediorder/JediMaster.py", line 29, in launcher
    mod = __import__(moduleName)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/panda/lib/python3.11/site-packages/pandajedi/jediorder/JediMsgProcessor.py", line 2, in <module>
    from pandacommon.pandamsgbkr import msg_processor
  File "/opt/panda/lib/python3.11/site-packages/pandacommon/pandamsgbkr/msg_processor.py", line 14, in <module>
    from .msg_bkr_utils import MBListenerProxy, MBSenderProxy, MsgBuffer
  File "/opt/panda/lib/python3.11/site-packages/pandacommon/pandamsgbkr/msg_bkr_utils.py", line 24, in <module>
    stomp_logger = stomp.logging.__logger
                   ^^^^^^^^^^^^^
AttributeError: module 'stomp' has no attribute 'logging'
```

They seem to be due to the fact that the latest panda-common tag is not used (https://github.com/PanDAWMS/panda-common/releases/tag/0.1.9), which addressed the change described [here](https://codeberg.org/jasonrbriggs/stomp.py/commit/cc5a9593ef0887d2efa889f2b52f723beb81b3ba) in how stomp gives access to logging.