### PR TITLE
Exclude GPU queues with mixed nodes that don't all meet minimum version requirements

### DIFF
--- a/pandajedi/jedibrokerage/AtlasBrokerUtils.py
+++ b/pandajedi/jedibrokerage/AtlasBrokerUtils.py
@@ -1113,8 +1113,10 @@ class JsonSoftwareCheck:
                                     continue
 
                             # check VRAM (in MB); supports operators: ==, >=, <=, >, <, != (e.g. ">=40960")
+                            # all() ensures every GPU entry in the queue meets the minimum — prevents brokering to
+                            # mixed sites where some nodes fall below the requirement
                             if "vram" in host_gpu_spec:
-                                if not wn_gpus or not any(g.get("vram") and compare_version_string(str(g["vram"]), host_gpu_spec["vram"]) for g in wn_gpus):
+                                if not wn_gpus or not all(g.get("vram") and compare_version_string(str(g["vram"]), host_gpu_spec["vram"]) for g in wn_gpus):
                                     continue
 
                             # check GPU microarchitecture generation (e.g. Ampere, Hopper, Ada Lovelace)
@@ -1126,15 +1128,19 @@ class JsonSoftwareCheck:
                                     continue
 
                             # check minimum CUDA version
+                            # all() ensures every GPU entry in the queue meets the minimum — prevents brokering to
+                            # mixed sites where some nodes fall below the requirement
                             if "version" in host_gpu_spec:
-                                if not wn_gpus or not any(
+                                if not wn_gpus or not all(
                                     g.get("framework_version") and compare_version_string(g["framework_version"], host_gpu_spec["version"]) for g in wn_gpus
                                 ):
                                     continue
 
                             # check minimum GPU driver version (kernel driver, e.g. 575.57.08)
+                            # all() ensures every GPU entry in the queue meets the minimum — prevents brokering to
+                            # mixed sites where some nodes fall below the requirement
                             if "driver_version" in host_gpu_spec:
-                                if not wn_gpus or not any(
+                                if not wn_gpus or not all(
                                     g.get("driver_version") and compare_version_string(g["driver_version"], host_gpu_spec["driver_version"]) for g in wn_gpus
                                 ):
                                     continue


### PR DESCRIPTION
When a task specifies a minimum CUDA version, driver version, or VRAM, the brokerage previously accepted a queue if *any* worker node entry in the monitoring data satisfied the constraint. This meant a queue with mixed nodes — e.g. both CUDA 12.2 and CUDA 12.9 — would be accepted for a task requiring `>=12.8`, and the job could land on a non-compliant 12.2 node.

This change switches the acceptance logic for minimum-requirement attributes from `any()` to `all()`:

- `version` (CUDA toolkit version): `any` → `all`
- `driver_version` (kernel driver version): `any` → `all`
- `vram`: `any` → `all`

A queue is now only accepted if every worker node entry satisfies the constraint. Queues with even one non-compliant node are excluded entirely.

Selection attributes (`vendor`, `model`, `microarchitecture`) retain `any()` semantics, since those express "does this site have this GPU type?" rather than a minimum requirement.

Note: `all()` returns False if any entry has `None` for the checked field (e.g. `driver_version` not reported by the pilot). This is intentionally conservative — an unknown value cannot be guaranteed compliant.