### PR TITLE
Fix WorkQueue.pack(): use flags=re.I instead of positional re.I argument

### DIFF
--- a/pandaserver/taskbuffer/WorkQueue.py
+++ b/pandaserver/taskbuffer/WorkQueue.py
@@ -125,7 +125,7 @@ class WorkQueue(object):
             # replace = to ==
             tmp_eval_str = tmp_eval_str.replace("=", "==")
             # replace LIKE
-            tmp_eval_str = re.sub("(?P<var>[^ \\(]+)\\s+LIKE\\s+(?P<pat>[^ \\(]+)", "re.search(\\g<pat>,\\g<var>,re.I) is not None", tmp_eval_str, flags=re.I)
+            tmp_eval_str = re.sub(r"(?P<var>[^ \(]+)\s+LIKE\s+(?P<pat>[^ \(]+)", r"re.search(\g<pat>,\g<var>,re.I) is not None", tmp_eval_str, flags=re.I)
             # NULL
             tmp_eval_str = re.sub(" IS NULL", "==None", tmp_eval_str)
             tmp_eval_str = re.sub(" IS NOT NULL", "!=None", tmp_eval_str)

--- a/pandaserver/taskbuffer/WorkQueue.py
+++ b/pandaserver/taskbuffer/WorkQueue.py
@@ -119,18 +119,18 @@ class WorkQueue(object):
         else:
             tmp_eval_str = self.criteria
             # replace IN/OR/AND to in/or/and
-            tmp_eval_str = re.sub(" IN ", " in ", tmp_eval_str, re.I)
-            tmp_eval_str = re.sub(" OR ", " or ", tmp_eval_str, re.I)
-            tmp_eval_str = re.sub(" AND ", " and ", tmp_eval_str, re.I)
+            tmp_eval_str = re.sub(" IN ", " in ", tmp_eval_str, flags=re.I)
+            tmp_eval_str = re.sub(" OR ", " or ", tmp_eval_str, flags=re.I)
+            tmp_eval_str = re.sub(" AND ", " and ", tmp_eval_str, flags=re.I)
             # replace = to ==
             tmp_eval_str = tmp_eval_str.replace("=", "==")
             # replace LIKE
-            tmp_eval_str = re.sub("(?P<var>[^ \(]+)\s+LIKE\s+(?P<pat>[^ \(]+)", "re.search(\g<pat>,\g<var>,re.I) is not None", tmp_eval_str, re.I)
+            tmp_eval_str = re.sub("(?P<var>[^ \\(]+)\\s+LIKE\\s+(?P<pat>[^ \\(]+)", "re.search(\\g<pat>,\\g<var>,re.I) is not None", tmp_eval_str, flags=re.I)
             # NULL
             tmp_eval_str = re.sub(" IS NULL", "==None", tmp_eval_str)
             tmp_eval_str = re.sub(" IS NOT NULL", "!=None", tmp_eval_str)
             # replace NOT to not
-            tmp_eval_str = re.sub(" NOT ", " not ", tmp_eval_str, re.I)
+            tmp_eval_str = re.sub(" NOT ", " not ", tmp_eval_str, flags=re.I)
             # format cases
             for tmp_param in self._paramsForSelection:
                 tmp_eval_str = re.sub(tmp_param, tmp_param, tmp_eval_str, re.I)


### PR DESCRIPTION
The re.sub() calls were passing re.I as the 4th positional argument (count), not as flags=re.I. This meant only the first AND/OR/NOT/IN/LIKE/NULL replacement would occur, causing eval() failures for criteria with multiple conditions.

Example broken criteria:
`'prodSourceLabel="test" AND processingType="x" AND workingGroup="EIC"'`
After pack():
`'prodSourceLabel="test" and processingType="x" AND workingGroup="EIC"'`
The 2nd+ AND remain uppercase -> eval() crashes with NameError: AND

Fixed by using flags=re.I keyword argument in all re.sub() calls.

n.b. use of positional count and flags arguments are deprecated in Python 3.13 https://docs.python.org/3/library/re.html