### PR TITLE
Add generator filter efficiency handling to adder plugins

### DIFF
--- a/pandaserver/dataservice/DataServiceUtils.py
+++ b/pandaserver/dataservice/DataServiceUtils.py
@@ -2,6 +2,15 @@ import re
 
 from pandaserver.taskbuffer import JobUtils
 
+# Job-level values taken from the executor metaData in job reports, mapped from the job
+# report key to the file metadata key they are registered under in DDM. This is the only
+# place to extend when another value is picked up: the adder reads the job report through
+# it and the DDM registration derives its metadata keys from it.
+EXECUTOR_METADATA_KEYS = {"cross-section (nb)": "xsec", "GenFiltEff": "gen_filt_eff"}
+
+# file metadata keys those job-level values are registered under
+JOB_LEVEL_METADATA_KEYS = list(EXECUTOR_METADATA_KEYS.values())
+
 
 def isCachedFile(dataset_name, site_spec):
     """

--- a/pandaserver/dataservice/adder_atlas_plugin.py
+++ b/pandaserver/dataservice/adder_atlas_plugin.py
@@ -425,9 +425,11 @@ class AdderAtlasPlugin(AdderPluginBase):
                 file_attrs["panda_id"] = file.PandaID
                 if campaign not in ["", None]:
                     file_attrs["campaign"] = campaign
-                # cross-section from the job report, which is a job-level value
-                if file.type == "output" and self.extra_info.get("xsec") is not None:
-                    file_attrs["xsec"] = self.extra_info["xsec"]
+                # values from the job report that are job-level, so they apply to every output file
+                if file.type == "output":
+                    for info_key in DataServiceUtils.JOB_LEVEL_METADATA_KEYS:
+                        if self.extra_info.get(info_key) is not None:
+                            file_attrs[info_key] = self.extra_info[info_key]
 
                 # For files uploaded to alternative RSEs
                 has_normal_url = True

--- a/pandaserver/dataservice/adder_gen.py
+++ b/pandaserver/dataservice/adder_gen.py
@@ -17,7 +17,7 @@ from pandacommon.pandautils.PandaUtils import naive_utcnow
 import pandaserver.dataservice.ErrorCode
 import pandaserver.taskbuffer.ErrorCode
 from pandaserver.config import panda_config
-from pandaserver.dataservice import closer
+from pandaserver.dataservice import DataServiceUtils, closer
 from pandaserver.srvcore.CoreUtils import normalize_cpu_model
 from pandaserver.taskbuffer import EventServiceUtils, JobUtils, retryModule
 
@@ -65,7 +65,7 @@ class AdderGen:
             "lbnr": {},
             "endpoint": {},
             "guid": {},
-            "xsec": None,
+            **{key: None for key in DataServiceUtils.JOB_LEVEL_METADATA_KEYS},
         }
         self.attempt_nr = attempt_nr
         self.pid = pid
@@ -672,9 +672,9 @@ class AdderGen:
         except Exception:
             self.logger.error(f"update_worker_node_gpu: issue with updating worker node GPU specs: {traceback.format_exc()}")
 
-    def extract_cross_section(self, json_dict: dict) -> None:
+    def extract_executor_metadata(self, json_dict: dict) -> None:
         """
-        Extract the generator cross-section from the job report and set it in extra_info.
+        Extract values from the executor metaData in the job report and set them in extra_info.
 
         :param json_dict: The job report as a dictionary.
         """
@@ -682,12 +682,21 @@ class AdderGen:
             executors = json_dict.get("executor", [])
             for executor in executors:
                 meta_data = executor.get("metaData", {})
-                if not isinstance(meta_data, dict) or "cross-section (nb)" not in meta_data:
+                if not isinstance(meta_data, dict):
                     continue
-                self.extra_info["xsec"] = float(meta_data["cross-section (nb)"])
-                return
+                for report_key, info_key in DataServiceUtils.EXECUTOR_METADATA_KEYS.items():
+                    if self.extra_info[info_key] is not None or report_key not in meta_data:
+                        continue
+                    # one unusable value must not discard the others
+                    try:
+                        self.extra_info[info_key] = float(meta_data[report_key])
+                    except (TypeError, ValueError) as e:
+                        self.logger.warning(f"extract_executor_metadata: ignored {report_key}={meta_data[report_key]}: {e}")
+                # stop once every value is filled
+                if all(self.extra_info[info_key] is not None for info_key in DataServiceUtils.JOB_LEVEL_METADATA_KEYS):
+                    return
         except Exception as e:
-            self.logger.warning(f"extract_cross_section: failed to extract cross-section from job report: {e}")
+            self.logger.warning(f"extract_executor_metadata: failed to extract metadata from job report: {e}")
 
     # parse JSON
     # 0: succeeded, 1: harmless error to exit, 2: fatal error, 3: event service
@@ -816,11 +825,11 @@ class AdderGen:
             self.logger.warning("Issue with parsing JSON for nEvents")
             pass
 
-        # parse metadata to get worker node specs, GPU specs, and cross-section
+        # parse metadata to get worker node specs, GPU specs, and executor metadata
         if isinstance(json_dict, dict):
             self.update_worker_node(json_dict)
             self.update_worker_node_gpu(json_dict)
-            self.extract_cross_section(json_dict)
+            self.extract_executor_metadata(json_dict)
 
         # use nEvents and GUIDs reported by the pilot if no job report
         if self.job.metadata == "NULL" and self.job_status == "finished" and self.job.nEvents > 0 and self.job.prodSourceLabel in ["managed"]:

--- a/pandaserver/dataservice/ddm.py
+++ b/pandaserver/dataservice/ddm.py
@@ -37,6 +37,7 @@ from rucio.common.exception import (
     UnsupportedOperation,
 )
 
+from pandaserver.dataservice import DataServiceUtils
 from pandaserver.srvcore import CoreUtils
 from pandaserver.srvcore.exceptions import DatasetLocationError, FileRegistrationError, SubscriptionRegistrationError
 
@@ -384,7 +385,7 @@ class RucioAPI:
         lfn = tmp_file.get("name", tmp_file.get("lfn"))
         file_scope, lfn = lfn.split(":") if ":" in lfn else (scope, lfn)
         # set metadata
-        meta_keys = ["guid", "events", "lumiblocknr", "panda_id", "campaign", "task_id", "xsec"]
+        meta_keys = ["guid", "events", "lumiblocknr", "panda_id", "campaign", "task_id"] + DataServiceUtils.JOB_LEVEL_METADATA_KEYS
         meta = {key: tmp_file[key] for key in meta_keys if key in tmp_file}
         file_size = tmp_file.get("bytes", tmp_file.get("size"))
         file = {"scope": file_scope, "name": lfn, "bytes": file_size, "meta": meta}


### PR DESCRIPTION
- Introduced EXECUTOR_METADATA_KEYS in DataServiceUtils as the single place defining which job report metaData keys are picked up and which file metadata keys they are registered under. AdderGen, AdderAtlasPlugin and RucioAPI all derive their keys from it, so adding another value is a one-line change.
- Generalized the cross-section extraction in AdderGen into extract_executor_metadata, which now picks up GenFiltEff as well.
- Updated AdderAtlasPlugin to set every job-level value on output files.
- Modified RucioAPI to register those values as file metadata.

Values are converted per key so one unusable value no longer discards the others, and the scan continues across executors until every value is filled.